### PR TITLE
Fixing a crash bug trying to print out stderr.

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ exports.generatePdf = function(data, templatePath, callback) {
 
         // Check if Error thrown from exec
         if (error) {
-          console.error('exec error: ' + error + '\n' + stderrt);
+          console.error('exec error: ' + error + '\n' + stderr);
           callback(err);
         }
 


### PR DESCRIPTION
Variable name is misspelt which causes the module to throw an exception.