### PR TITLE
Remove ghostscript.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
  - "5"
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get -y install pdftk ghostscript
+  - sudo apt-get -y install pdftk

--- a/README.md
+++ b/README.md
@@ -2,24 +2,23 @@
 
 [![Build Status](https://travis-ci.org/dommmel/fill-pdf.svg?branch=master)](https://travis-ci.org/dommmel/fill-pdf)
 
-A node module to fill out pdf forms (utf8 compatible).
+A node module to fill out PDF forms (utf8 compatible).
 
-It uses [pdftk](http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/) to fill out pdf forms and [ghostscript](http://www.ghostscript.com/) to convert embedded fonts to outlines to increase cross-device robustness.
+It uses [pdftk](http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/) to fill out PDF forms.
 
 ## Installation
     npm install fill-pdf
  
 ## Dependencies
-You need to have the ```pdftk``` an ```gs``` binaries in your PATH.  
+You need to have the ```pdftk``` binary in your PATH.
 
 
 ### Install on Mac OSX
 
 * To install PDFtk use [the official installer](http://www.pdflabs.com/tools/pdftk-server/) or if you have [homebrew-cask](https://github.com/phinze/homebrew-cask) installed you can run ```brew cask install pdftk```
-* To install Ghoscript via homebrew run :```brew install ghostscript```
 
 ### Install on Ubuntu
-```sudo apt-get install pdftk ghostscript```
+```sudo apt-get install pdftk```
 
 ## Usage example (with express)
 
@@ -29,7 +28,7 @@ var formDate = { FieldName: 'Text to put into form field' };
 var pdfTemplatePath = "templates.pdf";
 
 app.get('/filled_form.pdf', function(req, res) {
-  fillPdf.generatePdf(formDate,pdfTemplatePath, function(err, output) {
+  fillPdf.generatePdf(formDate, pdfTemplatePath, function(err, output) {
     if ( !err ) {
       res.type("application/pdf");
       res.send(output);
@@ -39,4 +38,4 @@ app.get('/filled_form.pdf', function(req, res) {
 ```
 
 ## Acknowledgements
-based on [utf8-fdf-generator](https://www.npmjs.org/package/utf8-fdf-generator)
+Based on [utf8-fdf-generator](https://www.npmjs.org/package/utf8-fdf-generator)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var fs    = require('fs'),
     path  = require('path'),
-    exec  = require('child_process').exec,
     spawn = require('child_process').spawn,
     temp  = require('temp');
 


### PR DESCRIPTION
I came across a use case where GhostScript was preventing the library from working.

I was filling a PDF form which used some fonts that were not embedded.  Since ghostscript tried replacing the fonts with outlines, it would spit out a warning if a font wasn't found.  Unfortunately, warnings were being sent to stderr and I could not find any way to suppress them.  As a result, I removed ghostscript and now I am able to generate PDFs again.