### PR TITLE
Asyncify and Extract `generatePdf`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,62 @@
+{
+  /*
+   * ENVIRONMENTS
+   * =================
+   */
+
+  // Define globals exposed by modern browsers.
+  "browser": true,
+
+  // Define globals exposed by jQuery.
+  "jquery": true,
+
+  // Define globals exposed by Node.js.
+  "node": true,
+
+  // Allow ES6.
+  "esversion": 6,
+
+  /*
+   * ENFORCING OPTIONS
+   * =================
+   */
+
+  // Force all variable names to use either camelCase style or UPPER_CASE
+  // with underscores.
+  "camelcase": true,
+
+  // Prohibit use of == and != in favor of === and !==.
+  "eqeqeq": true,
+
+  // Enforce tab width of 2 spaces.
+  "indent": 2,
+
+  // Prohibit use of a variable before it is defined.
+  "latedef": true,
+
+  // Enforce line length to 100 characters
+  "maxlen": 100,
+
+  // Require capitalized names for constructor functions.
+  "newcap": true,
+
+  // Enforce use of single quotation marks for strings.
+  "quotmark": "single",
+
+  // Enforce placing 'use strict' at the top function scope
+  "strict": true,
+
+  // Prohibit use of explicitly undeclared variables.
+  "undef": true,
+
+  // Warn when variables are defined but never used.
+  "unused": true,
+
+  /*
+   * RELAXING OPTIONS
+   * =================
+   */
+
+  // Suppress warnings about == null comparisons.
+  "eqnull": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
- - "5"
+ - "6"
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get -y install pdftk

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+ - "4"
+ - "5"
  - "6"
 before_install:
   - sudo apt-get -qq update

--- a/index.js
+++ b/index.js
@@ -41,9 +41,9 @@ exports.generatePdf = function(data, templatePath, extendArgs, callback) {
 
   let child = spawn('pdftk', processArgs);
 
-  writeFdfToPdftk(child, data);
   handlePdftkError(child, callback);
   handlePdftkExit(child, tempNameResult, callback);
+  writeFdfToPdftk(child, data);
 };
 
 function normalizeArgs(extendArgs, callback) {

--- a/index.js
+++ b/index.js
@@ -87,10 +87,8 @@ function createHandlePdftkExit(tempNameResult, callback) {
       (cb) => {
         fs.readFile(tempNameResult, (err, filledPdf) => cb(err, filledPdf));
       },
-      (cb, filledPdf) => {
-        fs.unlink(tempNameResult, function(err) {
-          callback(err, filledPdf);
-        });
+      (filledPdf, cb) => {
+        fs.unlink(tempNameResult, (err) => cb(err, filledPdf));
       }
     ],
     function(err, result) {

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
-var fs    = require('fs'),
+'use strict';
+
+const fs  = require('fs'),
     path  = require('path'),
     spawn = require('child_process').spawn,
+    async = require('async'),
     temp  = require('temp');
 
 exports.generateFdf = function(data) {
   var header, body, footer, dataKeys;
 
-  // We should really come up with a new way of making FDF files, this is doing a lot of buffer instantiation.
+  header = new Buffer('%FDF-1.2\n\u00e2\u00e3\u00cf\u00d3\n1 0 obj \n<<\n/FDF \n<<\n/Fields [\n');
 
-  header = new Buffer("%FDF-1.2\n\u00e2\u00e3\u00cf\u00d3\n1 0 obj \n<<\n/FDF \n<<\n/Fields [\n");
-
-  footer = new Buffer("]\n>>\n>>\nendobj \ntrailer\n\n<<\n/Root 1 0 R\n>>\n%%EOF\n");
+  footer = new Buffer(']\n>>\n>>\nendobj \ntrailer\n\n<<\n/Root 1 0 R\n>>\n%%EOF\n');
 
   dataKeys = Object.keys(data);
 
@@ -18,58 +19,48 @@ exports.generateFdf = function(data) {
 
   for(var i=0; i<dataKeys.length; i++) {
     var name = dataKeys[i].toString();
-    var value = data[name].toString().replace("\r\n","\r");
+    var value = data[name].toString().replace('\r\n','\r');
 
-    body = Buffer.concat([ body, new Buffer("<<\n/T (" + name + ")\n/V (" + value + ")\n>>\n") ]);
+    body = Buffer.concat([ body, new Buffer('<<\n/T (' + name + ')\n/V (' + value + ')\n>>\n') ]);
   }
 
   var fdf =  Buffer.concat([ header, body, footer ]);
   return fdf;
-}
+};
 
 exports.generatePdf = function(data, templatePath, extendArgs, callback) {
   var tempNameResult = temp.path({suffix: '.pdf'}),
       pdfPath        = isAbsolute(templatePath) ? templatePath : path.join(__dirname, templatePath);
 
-  extendArgs = normalizeArgs(extendArgs, callback);
+  [extendArgs, callback] = normalizeArgs(extendArgs, callback);
 
-  console.log(extendArgs);
-  console.log(callback);
+  var processArgs = [pdfPath, 'fill_form', '-', 'output', tempNameResult].concat(extendArgs);
 
-  var processArgs = [pdfPath, "fill_form", "-", "output", tempNameResult].concat(extendArgs);
+  let child = spawn('pdftk', processArgs);
 
-  child = spawn("pdftk", processArgs);
+  writeFdfToPdftk(child, data);
+  handlePdftkError(child, callback);
+  handlePdftkExit(child, tempNameResult, callback);
+};
 
-  child.on('exit', function(code) {
+function normalizeArgs(extendArgs, callback) {
+  // Check if extendArgs is our callback, adds backwards compat
+  if (typeof extendArgs === 'function') {
+   callback = extendArgs;
+   extendArgs = [];
+  }
+  else if (!(extendArgs instanceof Array)) {
+    extendArgs = [];
+  }
+  return [extendArgs, callback];
+}
 
-    // If a exit code besides 0 was thrown then send an error
-    if ( code ) {
-      callback(new Error('Non 0 exit code from pdftk spawn: ' + code));
-    }
-
-    // Async read tempfile, we should think about making this a stream instead of a read into memory.
-    fs.readFile(tempNameResult, function(err, filledPdf) {
-
-      if ( err ) {
-        return callback(err);
-      }
-
-      // Delete files, doing nested callbacks for now, but lets look into maybe using async for this
-      fs.unlink(tempNameResult, function(err) {
-        if ( err ) {
-          return callback(err);
-        }
-
-        // Everything Looks good, send back pdfFile.
-        callback(null, filledPdf);
-      });
-    });
-  });
-
-  // Write FDF file to pdftk spawned process
+function writeFdfToPdftk(child, data) {
   child.stdin.write(exports.generateFdf(data));
   child.stdin.end();
+}
 
+function handlePdftkError(child, callback) {
   child.on('error', function (err) {
     callback(err);
   });
@@ -77,25 +68,47 @@ exports.generatePdf = function(data, templatePath, extendArgs, callback) {
   child.stderr.on('data', function (data) {
     console.error('stderr: ' + data);
   });
+}
 
+function handlePdftkExit(child, tempNameResult, callback) {
+  child.on('exit', createHandlePdftkExit(tempNameResult, callback));
+}
+
+function createHandlePdftkExit(tempNameResult, callback) {
+  return function(code) {
+    if ( code ) {
+      return callback(new Error('Non 0 exit code from pdftk spawn: ' + code));
+    }
+
+    async.waterfall([
+      (cb) => {
+        fs.readFile(tempNameResult, (err, filledPdf) => cb(err, filledPdf));
+      },
+      (cb, filledPdf) => {
+        fs.unlink(tempNameResult, function(err) {
+          callback(err, filledPdf);
+        });
+      }
+    ],
+    function(err, result) {
+      callback(err, result);
+    });
+  };
 }
 
 function normalizeArgs(extendArgs, callback) {
   // Check if extendArgs is our callback, adds backwards compat
   if (typeof extendArgs === 'function') {
-    console.log('is a function');
    callback = extendArgs;
    extendArgs = [];
   }
-  else if (extendArgs instanceof Array) {
-    args = extendArgs;
-  }
-  else {
+  else if (!(extendArgs instanceof Array)) {
     extendArgs = [];
   }
-  return extendArgs;
+  return [extendArgs, callback];
 }
 
 function isAbsolute(Path) {
-    return (path.isAbsolute && path.isAbsolute(Path)) || (path.normalize(Path + '/') === path.normalize(path.resolve(Path) + '/'));
-};
+    return (path.isAbsolute && path.isAbsolute(Path)) ||
+           (path.normalize(Path + '/') === path.normalize(path.resolve(Path) + '/'));
+}

--- a/index.js
+++ b/index.js
@@ -29,12 +29,15 @@ exports.generateFdf = function(data) {
 };
 
 exports.generatePdf = function(data, templatePath, extendArgs, callback) {
-  var tempNameResult = temp.path({suffix: '.pdf'}),
+  let tempNameResult = temp.path({suffix: '.pdf'}),
       pdfPath        = isAbsolute(templatePath) ? templatePath : path.join(__dirname, templatePath);
 
-  [extendArgs, callback] = normalizeArgs(extendArgs, callback);
+  let normalized = normalizeArgs(extendArgs, callback);
 
-  var processArgs = [pdfPath, 'fill_form', '-', 'output', tempNameResult].concat(extendArgs);
+  extendArgs = normalized.args;
+  callback   = normalized.callback;
+
+  let processArgs = [pdfPath, 'fill_form', '-', 'output', tempNameResult].concat(extendArgs);
 
   let child = spawn('pdftk', processArgs);
 
@@ -52,7 +55,7 @@ function normalizeArgs(extendArgs, callback) {
   else if (!(extendArgs instanceof Array)) {
     extendArgs = [];
   }
-  return [extendArgs, callback];
+  return { args: extendArgs, callback: callback };
 }
 
 function writeFdfToPdftk(child, data) {
@@ -105,7 +108,7 @@ function normalizeArgs(extendArgs, callback) {
   else if (!(extendArgs instanceof Array)) {
     extendArgs = [];
   }
-  return [extendArgs, callback];
+  return { args: extendArgs, callback: callback };
 }
 
 function isAbsolute(Path) {

--- a/index.js
+++ b/index.js
@@ -31,17 +31,10 @@ exports.generatePdf = function(data, templatePath, extendArgs, callback) {
   var tempNameResult = temp.path({suffix: '.pdf'}),
       pdfPath        = isAbsolute(templatePath) ? templatePath : path.join(__dirname, templatePath);
 
-  // Check if extendArgs is our callback, adds backwards compat
-  if (typeof extendArgs === 'function') {
-   callback = extendArgs;
-   extendArgs = [];
-  }
-  else if (extendArgs instanceof Array) {
-    args = extendArgs;
-  }
-  else {
-    extendArgs = [];
-  }
+  extendArgs = normalizeArgs(extendArgs, callback);
+
+  console.log(extendArgs);
+  console.log(callback);
 
   var processArgs = [pdfPath, "fill_form", "-", "output", tempNameResult].concat(extendArgs);
 
@@ -85,6 +78,22 @@ exports.generatePdf = function(data, templatePath, extendArgs, callback) {
     console.error('stderr: ' + data);
   });
 
+}
+
+function normalizeArgs(extendArgs, callback) {
+  // Check if extendArgs is our callback, adds backwards compat
+  if (typeof extendArgs === 'function') {
+    console.log('is a function');
+   callback = extendArgs;
+   extendArgs = [];
+  }
+  else if (extendArgs instanceof Array) {
+    args = extendArgs;
+  }
+  else {
+    extendArgs = [];
+  }
+  return extendArgs;
 }
 
 function isAbsolute(Path) {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/dommmel/fill-pdf",
   "dependencies": {
+    "async": "^2.0.0-rc.6",
     "temp": "~0.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fill-pdf",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Fill out pdf forms",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
ping @westy92 

**This PR requires Node v6**

So, `generatePdf()` was a long and over complicated function. I decided to extract out a lot of logic into their own function to make `generatePdf()` more readable in general. 

Part of this PR is also wrapping the pdftk integrations and cleanup into `async.waterfall`

note: also added airbnb jshintrc file.

Also, how arguments are sent to `generatePdf` are a bit awkard, should start to look at changing it to an object of parameters:

```js
fillPdf.generatePdf({
  data: data,
  pathToPdf: 'path/to/file.pdf',
  callback: handle
});
```